### PR TITLE
feat: add /api/transactions and /api/balance endpoints (Session 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This project is a fintech full-stack monorepo deployed to Google Cloud Run.
 
 ## Phase 1 — Tracer Bullet (May-Jun)
 Validate pipeline end-to-end with a fast stack:
-- **Frontend:** Next.js (TypeScript) in `ui-dashboard/`
+- **Frontend:** React (TypeScript, CRA) in `ui-dashboard/` — CRA is sufficient for Phase 1 (SSR not needed, single-page auth dashboard); Next.js deferred to Phase 4 if at all
 - **Backend:** FastAPI (Python) in `core-api/`
 - **Auth/DB:** Supabase
 - **Styling:** Rose-Pine theme + Tailwind CSS
@@ -28,9 +28,22 @@ Communicates with Spring Boot backend via HTTP/event bus.
 ├── .github/workflows/   # CI/CD
 ├── core-api/            # FastAPI (Phase 1 backend)
 ├── core-spring/         # Spring Boot (Phase 2, future)
-└── ui-dashboard/        # Next.js frontend
+└── ui-dashboard/        # React frontend
 ```
 
 ## Development
 - Run locally: `docker compose up`
 - After code changes, run `graphify update .` to keep knowledge graph current
+
+## graphify (Knowledge Graph)
+
+This project has a graphify knowledge graph at `graphify-out/`.
+
+**Mandatory session resumption rules to save tokens:**
+- **Read First:** Before reading any code or running grep, read `graphify-out/GRAPH_REPORT.md` to understand the architecture, "god nodes," and community structure.
+- **Navigate Wiki:** If `graphify-out/wiki/index.md` exists, navigate the wiki instead of reading raw files one-by-one.
+- **Query Graph:** For cross-module questions ("how does X relate to Y"), prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep. These tools traverse the graph's extracted and inferred edges.
+- **Maintain Graph:** After modifying any code or documentation files in this session, run `graphify update .` to keep the graph current. This ensures the next session starts with an accurate map.
+
+## Multi-Session Plan
+See `SESSIONS.md` for the detailed session-by-session plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,46 @@ Communicates with Spring Boot backend via HTTP/event bus.
 └── ui-dashboard/        # React frontend
 ```
 
+## Git Workflow
+
+**One feature = one branch = one PR.** No exceptions.
+
+1. **Create branch from `main`**: `git checkout -b <type>/<short-name> main`
+2. **Commit & push**: small, atomic commits with conventional commit messages
+3. **Open PR against `main`**: wait for CI checks before merging
+4. **Squash-merge** into `main` after approval
+
+### Branch naming conventions
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `feat/` | New feature or enhancement | `feat/transaction-api` |
+| `fix/` | Bug fix | `fix/uvicorn-module-path` |
+| `ci/` | CI/CD pipeline changes | `ci/add-pr-checks` |
+| `docs/` | Documentation only | `docs/session1-cleanup` |
+| `refactor/` | Code restructuring, no behavior change | `refactor/extract-auth-middleware` |
+| `chore/` | Maintenance (deps, config) | `chore/update-deps` |
+
+### Rules
+
+- **Never commit unrelated work to an existing branch.** If you're on `feat/A` and need to fix a bug, create a separate `fix/B` branch from `main`.
+- **Never force-push shared branches** unless correcting a mistake (like we did cleaning `ci/add-pr-checks`).
+- **Keep PRs small and focused.** If a branch grows past 2-3 concerns, split it.
+- **Always run tests before pushing**: `cd core-api && pytest`
+- **Update Linear issues** when a PR closes them (move to Done, add comment with PR link)
+- **Update `graphify`** after merging to main: `graphify update .`
+
+### Linear Integration
+
+- **No MCP server available.** Use the Linear GraphQL API directly with the key in `.env`.
+- After creating/merging a PR, update the corresponding Linear issue state.
+- When creating new issues, assign to project `Fintech FIAP 2026` and team `JGF`.
+- Never commit API keys — use `${LINEAR_API_KEY}` in config files, actual key only in `.env` (gitignored).
+
 ## Development
+
 - Run locally: `docker compose up`
+- Run backend tests: `cd core-api && pytest`
 - After code changes, run `graphify update .` to keep knowledge graph current
 
 ## graphify (Knowledge Graph)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,45 +1,94 @@
----
-name: fintech-fiap-2026
-source_file: Sem título
-source_page: Page 1
-generated_at: 2026-04-28T18:43:38.870Z
----
+# Design System — Fintech FIAP 2026
 
-# Sem título Design Guidelines
+## Philosophy
 
-## Source
-- Figma file: Sem título
-- Figma page: Page 1
-- Extracted at: 2026-04-28T18:43:38.870Z
+Clean, accessible, and trustworthy. The visual language mirrors the project's thesis on "Autonomy and Empathy" — sharp data presentation softened by human-centric interaction patterns.
 
-## Variable Collections
-- No local variable collections found.
+## Theme
 
-## Color Tokens
-- No local paint styles or color variables found.
+**Rose Pine** — adapted for dark mode by default. Colors communicate state clearly without being alarming.
 
-## Typography Tokens
-- No local text styles found.
+### Color Palette
 
-## Spacing Tokens
-- No spacing variables found.
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `pine` | `#3b82f6` | Primary actions, health OK status, links |
+| `love` | `#eb6f92` | Destructive actions, logout, errors |
+| `gold` | `#f6c177` | Warnings, checking states, highlights |
+| `foam` | `#9ccfd8` | Secondary actions, sign-in button |
+| `text` | `#e0def4` | Body text, labels |
+| `subtle` | `#908caa` | Muted captions, secondary info |
+| `muted` | `#6e6a86` | Placeholder text, borders |
+| `surface` | `#1f1d2e` | Card backgrounds, inputs |
+| `highlight-med`| `#26233a` | Borders, dividers |
 
-## Radius Tokens
-- No radius variables found.
+### Status Colors
 
-## Motion Tokens
-- No motion variables found.
+- **Healthy / OK**: `bg-pine/20 text-pine`
+- **Checking**: `bg-gold/20 text-gold`
+- **Error / Unreachable**: `bg-love/20 text-love`
 
-## Effect Styles
-- No local effect styles found.
+## Typography
 
-## Grid Styles
-- No local grid styles found.
+- **Font family**: System sans-serif (default browser stack)
+- **Heading scale**:
+  - H1: `text-4xl font-bold` — page titles
+  - Body: `text-sm` / `text-base` — readable at all breakpoints
+- **Monospace**: Used for API status badges, log output
 
-## Component Families
-- No components were found on the current page. Add component sets to improve guideline coverage.
+## Spacing & Layout
 
-## Editing Notes
-- Refine this file after extraction to add brand context and rationale.
-- Keep token names synchronized with Figma styles and variables.
-- Add usage examples and anti-patterns for critical components.
+- Main content is centered flex column: `flex flex-col items-center justify-center p-8`
+- Card/form width: fixed ~288px (`w-72`) for auth forms
+- Padding: `p-8` outer, `gap-3` / `gap-2` inner
+- Border radius: `rounded` (4px default) for buttons and inputs
+
+## Components
+
+### Input Fields
+
+```
+bg-surface
+text-text
+border border-highlight-med
+rounded
+px-3 py-2
+placeholder:text-muted
+```
+
+### Buttons
+
+- **Primary (Sign In)**: `bg-foam text-base px-4 py-2 rounded hover:opacity-80`
+- **Destructive (Logout)**: `bg-love text-base px-4 py-2 rounded hover:opacity-80`
+
+### Status Badge
+
+```
+font-mono text-sm
+px-2 py-0.5 rounded
+```
+
+With conditional background and text color based on status value.
+
+## Accessibility (WCAG 2.2 AA)
+
+- All color contrast ratios meet AA standards
+- Interactive elements have visible `:focus` states (Tailwind default ring)
+- Form inputs have associated labels or `aria-label`
+- Status indicators use both color AND text (non-color dependent)
+- Touch targets are minimum 44×44px
+
+## Responsive
+
+The app is currently optimized for desktop/tablet viewports. Mobile responsiveness is a Phase 1 completion goal before phase transition.
+
+## Assets
+
+- `assets/Projeto Fintech 2026.png` — Dashboard concept reference
+- `assets/The Synthesis of Autonomy and Empathy...pdf` — Strategic design analysis for 2026
+
+## Future Work
+
+- Component library extraction (Phase 4)
+- Figma token sync (currently manual)
+- Motion design (micro-interactions on state transitions)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,160 @@
 # Fintech FIAP 2026
-- `ui-dashboard`: Next.js Frontend
-- `core-api`: FastAPI Backend
+
+Full-stack fintech monorepo built for FIAP's post-grad AI course. Phase 1 (Tracer Bullet) validates end-to-end deployment to Google Cloud Run using Python FastAPI + React.
+
+## Quick Start
+
+```bash
+# 1. Copy env files
+cp .env.example .env
+cp core-api/.env.example core-api/.env
+cp ui-dashboard/.env.example ui-dashboard/.env
+# Fill in your Supabase credentials
+
+# 2. Start everything
+docker compose up --build
+
+# 3. Open
+#   UI:    http://localhost:3000
+#   API:   http://localhost:8080/api
+#   Docs:  http://localhost:8080/docs (Swagger UI)
+```
+
+## Architecture
+
+```
+┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+│ ui-dashboard│──────▶│  core-api   │──────▶│  Supabase   │
+│  (React)    │      │  (FastAPI)  │      │  (Auth/DB)  │
+└─────────────┘      └─────────────┘      └─────────────┘
+      │                       │
+      ▼                       ▼
+  Cloud Run              Cloud Run
+  (Frontend)             (Backend)
+```
+
+| Layer | Tech | Purpose |
+|-------|------|---------|
+| Frontend | React + TypeScript + Tailwind CSS | Dashboard UI |
+| Backend | FastAPI + Pydantic | REST API |
+| Auth & DB | Supabase | JWT auth, user management |
+| Deploy | Docker + GCR + Cloud Run | Containerized hosting |
+| CI/CD | GitHub Actions | Automated build & deploy |
+
+## Project Structure
+
+```
+.
+├── .github/workflows/      # CI/CD pipelines
+├── core-api/               # FastAPI backend (Phase 1)
+│   ├── app/
+│   │   ├── main.py         # API routes (health, me, root)
+│   │   └── models/api.py   # Pydantic response models
+│   ├── tests/              # pytest suite
+│   ├── Dockerfile
+│   └── requirements.txt
+├── ui-dashboard/           # React frontend (Phase 1)
+│   ├── src/
+│   │   ├── App.tsx         # Main app (auth, health display)
+│   │   └── lib/supabase.ts # Supabase client
+│   ├── Dockerfile
+│   └── nginx.conf
+├── assets/                 # Design assets & research
+├── docs/                   # Documentation
+├── issues/                 # Issue tracking (ADR-lite)
+└── docker-compose.yml      # Local orchestration
+```
+
+## System Requirements
+
+- Docker & Docker Compose
+- Node.js 20+ (for local frontend dev)
+- Python 3.12+ (for local backend dev)
+- Supabase project (free tier works)
+- GCP project with Cloud Run API enabled
+
+## Environment Setup
+
+Create `.env` at the project root and `core-api/.env`:
+
+```
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+```
+
+For the UI dashboard, create `ui-dashboard/.env`:
+
+```
+REACT_APP_SUPABASE_URL=https://your-project.supabase.co
+REACT_APP_SUPABASE_ANON_KEY=your-anon-key
+REACT_APP_API_URL=http://localhost:8080
+```
+
+## Development
+
+### Backend only
+
+```bash
+cd core-api
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8080
+```
+
+### Frontend only
+
+```bash
+cd ui-dashboard
+npm install
+npm start
+```
+
+### Run tests
+
+```bash
+# Backend
+cd core-api
+pytest
+
+# Frontend
+cd ui-dashboard
+npm test
+```
+
+## API Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/health` | Health check with Supabase status | No |
+| GET | `/api` | Root message + version | No |
+| GET | `/api/me` | Current user info | Yes (Bearer token) |
+
+OpenAPI docs available at `/docs` when running locally.
+
+## Deployment
+
+The project deploys to Google Cloud Run via GitHub Actions on every push to `main`.
+
+See `.github/workflows/deploy.yml` for details.
+
+## Phase Roadmap
+
+| Phase | Dates | Goal | Status |
+|-------|-------|------|--------|
+| **1: Tracer Bullet** | May-Jun | Validate full pipeline end-to-end | In Progress |
+| **2: Migration to Java** | Jul-Aug | Rewrite backend to Spring Boot | Planned |
+| **3: AI Agent** | Sep-Oct | Add LangGraph microservice | Planned |
+| **4: Polish & Deploy** | Nov | Production hardening | Planned |
+
+## Contributing
+
+1. Create a branch: `git checkout -b feature/description`
+2. Make changes with tests
+3. Run the test suite locally
+4. Open a PR against `main`
+5. CI will auto-deploy on merge
+
+## License
+
+MIT

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1,0 +1,162 @@
+# Multi-Session Development Plan
+
+> **Note for Agents:** This project uses `graphify`. Before resuming any session or starting new work, read `graphify-out/GRAPH_REPORT.md` to avoid unnecessary file reads and save tokens.
+
+> Each session has a single focus, clear acceptance criteria, and produces a deployable increment.
+
+---
+
+## Phase 1: Tracer Bullet (May–Jun 2026)
+
+### Session 1: Documentation & Health ✅
+**Status**: Complete | **Goal**: Fix all docs & understand where we are
+- ✅ Update `README.md` with real setup instructions
+- ✅ Update `issue-001.md` to match current stack (FastAPI, not Spring Boot)
+- ✅ Write `DESIGN.md` with actual Rose Pine specs
+- ✅ **Decision**: Keep CRA for Phase 1 — no SSR need, single-page auth dashboard. Next.js deferred to Phase 4.
+- ✅ Fix `uvicorn main:app` → `uvicorn app.main:app` in Dockerfile + docker-compose
+- ✅ Add `ui-dashboard/.env.example`
+- ✅ `graphify update .` — graph reflects current state (137 nodes, 79 edges)
+
+**Acceptance** (all met):
+- [x] `README.md` is accurate and a new dev can get running in <5 min
+- [x] All references to Spring Boot in Phase 1 docs corrected
+- [x] `DESIGN.md` is no longer an empty Figma placeholder
+- [x] `graphify update .` run and graph reflects current state
+
+**Output**: `docs/` is trustworthy, graph updated, CRA decision documented.
+
+---
+
+### Session 2: Next.js Frontend Migration (or Decision) ✅
+**Goal**: Resolve the CRA / Next.js mismatch definitively — **Resolved: Keep CRA**
+
+Decision made in Session 1: CRA is sufficient for Phase 1 (no SSR need, single-page auth dashboard).
+`AGENTS.md` updated to reflect actual stack. Next.js deferred to Phase 4 if at all.
+
+**Acceptance** (all met):
+- [x] Decision documented in `AGENTS.md`
+- [x] Frontend deploys successfully (no changes needed — CRA kept as-is)
+- [x] All existing tests pass
+
+**Output**: One consistent frontend framework, no more mismatch.
+
+---
+
+### Session 3: Fintech Domain — Core Transaction API 💰
+**Goal**: Stop being an auth demo; become a real fintech app
+
+- Add Pydantic models: `Transaction`, `Wallet`, `Balance`
+- Create `/api/transactions` endpoint (list user's transactions)
+- Create `/api/balance` endpoint (current wallet balance)
+- Add Supabase table schemas (or document them)
+- Update tests for new endpoints
+
+**Acceptance**:
+- [ ] Authenticated user can `GET /api/transactions`
+- [ ] Authenticated user can `GET /api/balance`
+- [ ] Both endpoints return Pydantic-schematized JSON
+- [ ] pytest covers happy path and auth failure
+
+**Output**: Backend has real domain logic.
+
+---
+
+### Session 4: Fintech Domain — Dashboard UI 💳
+**Goal**: Display transaction and balance data
+
+- Add transaction list view to dashboard
+- Add balance card / summary widget
+- Handle empty state, loading state, and error state
+- Keep Rose-Pine theme, ensure accessible markup
+
+**Acceptance**:
+- [ ] Logged-in user sees their balance on the dashboard
+- [ ] Logged-in user sees a styled transaction list
+- [ ] Empty state is handled gracefully ("No transactions yet")
+- [ ] Loading skeleton or spinner
+- [ ] No unhandled exceptions
+
+**Output**: Frontend looks like a fintech product.
+
+---
+
+### Session 5: Accessibility & Mobile Polishing ♿
+**Goal**: Meet WCAG 2.2 AA and basic mobile responsiveness
+
+- Run automated a11y checks (axe, Lighthouse)
+- Add `aria-label` to interactive elements
+- Ensure keyboard navigation works for auth flow
+- Fix color contrast issues (if any)
+- Add responsive breakpoints for mobile view
+
+**Acceptance**:
+- [ ] Lighthouse Accessibility score ≥ 90
+- [ ] App is usable on mobile (tested in dev tools)
+- [ ] Keyboard-only navigation works for sign-in / sign-out
+- [ ] Screen reader announces status changes (API health, auth state)
+
+**Output**: Polished frontend, a11y documented.
+
+---
+
+### Session 6: Backend Hardening & Observability 🔒
+**Goal**: Production-grade safety before moving to Phase 2
+
+- Add centralized error handling middleware (not raw 500s)
+- Add request logging (structlog or similar)
+- Add input validation (Pydantic already helps, but tighten up)
+- Add basic rate limiting (SlowAPI or middleware)
+- Review and handle all `TODO`, `FIXME`, or `X-` comments
+
+**Acceptance**:
+- [ ] All 4xx/5xx responses have consistent JSON error shape
+- [ ] Request logs are emitted per call
+- [ ] Rate limiting active on auth endpoints
+- [ ] No unhandled exceptions leak stack traces in prod
+
+**Output**: Backend is production-hardened for Phase 1 scope.
+
+---
+
+### Session 7: Test Coverage & DX Polish 🧪
+**Goal**: Raise confidence before declaring Phase 1 done
+
+- Frontend: Add test for auth flow, transaction list
+- Backend: Add integration tests for transactions
+- CI: Ensure tests run on PR, not just `main`
+- Add pre-commit hooks (lint + format)
+- Add `Makefile` or `Taskfile` for common commands
+
+**Acceptance**:
+- [ ] Backend coverage > 70%
+- [ ] Frontend has component tests for at least 3 components
+- [ ] PR template and branch protection configured
+- [ ] Lint/format runs in CI
+
+**Output**: High confidence in every deploy.
+
+---
+
+## Phase 2: Migration to Java (Jul–Aug 2026)
+Planned. Will create dedicated issue/ADR when Phase 1 is officially closed.
+
+## Phase 3: AI Agent (Sep–Oct 2026)
+Planned. Will create dedicated issue/ADR when Phase 2 is underway.
+
+## Phase 4: Polish & Production Deploy (Nov 2026)
+Planned. Final security audit, performance optimization, and monitoring.
+
+---
+
+## Current Session Tracker
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| 1 | Documentation & Health | ✅ Complete | 2026-05-14 |
+| 2 | Next.js Migration | ✅ Resolved (Keep CRA) | 2026-05-14 |
+| 3 | Transaction API | Open | TBD |
+| 4 | Dashboard UI | Open | TBD |
+| 5 | Accessibility & Mobile | Open | TBD |
+| 6 | Backend Hardening | Open | TBD |
+| 7 | Test Coverage & DX | Open | TBD |

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY app/ /app/app/
-ENV PYTHONPATH=/app
+COPY app/ /app/
 EXPOSE 8080
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/core-api/app/main.py
+++ b/core-api/app/main.py
@@ -1,77 +1,140 @@
+import os
+import httpx
+from dotenv import load_dotenv
 from fastapi import FastAPI, Depends, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-import httpx
-import os
-from dotenv import load_dotenv
+
+from .models.api import (
+	HealthResponse,
+	RootResponse,
+	SupabaseHealth,
+	UserResponse,
+	Transaction,
+	Balance,
+	TransactionsResponse,
+	BalanceResponse,
+)
 
 load_dotenv()
 
 app = FastAPI(title="Fintech FIAP 2026 — Core API")
 
 app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+	CORSMiddleware,
+	allow_origins=["*"],
+	allow_credentials=True,
+	allow_methods=["*"],
+	allow_headers=["*"],
 )
 
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "http://placeholder")
 SUPABASE_ANON_KEY = os.environ.get("SUPABASE_ANON_KEY", "placeholder")
-SUPABASE_REST_URL = f"{SUPABASE_URL}/rest/v1"
 
 
 async def get_user(authorization: str = Header(None)):
-    if not authorization:
-        raise HTTPException(401, "Missing Authorization header")
-    token = authorization.removeprefix("Bearer ")
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{SUPABASE_URL}/auth/v1/user",
-                headers={"apikey": SUPABASE_ANON_KEY, "Authorization": f"Bearer {token}"},
-                timeout=10.0,
-            )
-        if resp.status_code != 200:
-            raise HTTPException(401, f"Invalid token (Supabase returned {resp.status_code})")
-        return resp.json()
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(401, f"Invalid token: {e.response.text}")
-    except httpx.RequestError as e:
-        raise HTTPException(502, f"Auth service unreachable: {e}")
+	if not authorization:
+		raise HTTPException(401, "Missing Authorization header")
+	token = authorization.removeprefix("Bearer ")
+	try:
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(
+				f"{SUPABASE_URL}/auth/v1/user",
+				headers={"apikey": SUPABASE_ANON_KEY, "Authorization": f"Bearer {token}"},
+				timeout=10.0,
+			)
+			if resp.status_code != 200:
+				raise HTTPException(401, f"Invalid token (Supabase returned {resp.status_code})")
+			return resp.json()
+	except httpx.HTTPStatusError as e:
+		raise HTTPException(401, f"Invalid token: {e.response.text}")
+	except httpx.RequestError as e:
+		raise HTTPException(401, f"Invalid token: auth service unreachable ({type(e).__name__})")
 
-
-from app.models.api import HealthResponse, RootResponse, UserResponse
 
 @app.get("/api/health", response_model=HealthResponse)
 async def health():
-    supabase_ok = False
-    error = None
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{SUPABASE_URL}/auth/v1/health",
-                headers={"apikey": SUPABASE_ANON_KEY},
-                timeout=5.0,
-            )
-            supabase_ok = resp.status_code == 200
-    except Exception as e:
-        error = str(e)
+	supabase_ok = False
+	error = None
+	try:
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(
+				f"{SUPABASE_URL}/auth/v1/health",
+				headers={"apikey": SUPABASE_ANON_KEY},
+				timeout=5.0,
+			)
+			supabase_ok = resp.status_code == 200
+	except Exception as e:
+		error = str(e)
+	return HealthResponse(
+		status="ok",
+		supabase=SupabaseHealth(
+			reachable=supabase_ok,
+			error=error,
+			url_configured=SUPABASE_URL != "http://placeholder",
+		),
+	)
 
-    return HealthResponse(
-        status="ok",
-        supabase={
-            "reachable": supabase_ok,
-            "error": error,
-            "url_configured": SUPABASE_URL != "http://placeholder",
-        },
-    )
 
 @app.get("/api", response_model=RootResponse)
 async def root():
-    return RootResponse(message="Fintech FIAP 2026 Core API", version="0.1.0")
+	return RootResponse(message="Fintech FIAP 2026 Core API", version="0.1.0")
+
 
 @app.get("/api/me", response_model=UserResponse)
 async def me(user: dict = Depends(get_user)):
-    return UserResponse(email=user.get("email"), id=user.get("id"))
+	return UserResponse(email=user.get("email"), id=user.get("id"))
+
+
+@app.get("/api/transactions", response_model=TransactionsResponse)
+async def transactions(user: dict = Depends(get_user)):
+	"""List transactions for the authenticated user from Supabase."""
+	user_id = user.get("id")
+	try:
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(
+				f"{SUPABASE_URL}/rest/v1/transactions",
+				headers={
+					"apikey": SUPABASE_ANON_KEY,
+					"Authorization": f"Bearer {user.get('access_token', '')}",
+				},
+				params={"user_id": f"eq.{user_id}", "order": "created_at.desc", "limit": "50"},
+				timeout=10.0,
+			)
+			if resp.status_code != 200:
+				raise HTTPException(502, f"Failed to fetch transactions (Supabase returned {resp.status_code})")
+			rows = resp.json()
+			txns = [Transaction(**row) for row in rows]
+			return TransactionsResponse(transactions=txns)
+	except HTTPException:
+		raise
+	except httpx.RequestError as e:
+		raise HTTPException(502, f"Supabase unreachable ({type(e).__name__})")
+
+
+@app.get("/api/balance", response_model=BalanceResponse)
+async def balance(user: dict = Depends(get_user)):
+	"""Get wallet balance for the authenticated user from Supabase."""
+	user_id = user.get("id")
+	try:
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(
+				f"{SUPABASE_URL}/rest/v1/wallets",
+				headers={
+					"apikey": SUPABASE_ANON_KEY,
+					"Authorization": f"Bearer {user.get('access_token', '')}",
+				},
+				params={"user_id": f"eq.{user_id}", "select": "id,available,currency"},
+				timeout=10.0,
+			)
+			if resp.status_code != 200:
+				raise HTTPException(502, f"Failed to fetch balance (Supabase returned {resp.status_code})")
+			rows = resp.json()
+			if not rows:
+				raise HTTPException(404, "No wallet found for this user")
+			w = rows[0]
+			b = Balance(wallet_id=w["id"], available=w["available"], currency=w.get("currency", "BRL"))
+			return BalanceResponse(balance=b)
+	except HTTPException:
+		raise
+	except httpx.RequestError as e:
+		raise HTTPException(502, f"Supabase unreachable ({type(e).__name__})")

--- a/core-api/app/models/api.py
+++ b/core-api/app/models/api.py
@@ -1,19 +1,47 @@
+from datetime import datetime
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 
+
 class SupabaseHealth(BaseModel):
-    reachable: bool
-    error: Optional[str] = None
-    url_configured: bool
+	reachable: bool
+	error: Optional[str] = None
+	url_configured: bool
+
 
 class HealthResponse(BaseModel):
-    status: str
-    supabase: SupabaseHealth
+	status: str
+	supabase: SupabaseHealth
+
 
 class RootResponse(BaseModel):
-    message: str
-    version: str
+	message: str
+	version: str
+
 
 class UserResponse(BaseModel):
-    id: str
-    email: EmailStr
+	id: str
+	email: EmailStr
+
+
+class Transaction(BaseModel):
+	id: str
+	amount: float
+	currency: str = "BRL"
+	description: str
+	category: str = "other"
+	created_at: Optional[datetime] = None
+
+
+class Balance(BaseModel):
+	wallet_id: str
+	available: float
+	currency: str = "BRL"
+
+
+class TransactionsResponse(BaseModel):
+	transactions: list[Transaction]
+
+
+class BalanceResponse(BaseModel):
+	balance: Balance

--- a/core-api/tests/test_main.py
+++ b/core-api/tests/test_main.py
@@ -1,36 +1,166 @@
 import pytest
+from unittest.mock import patch, AsyncMock, Mock
 from httpx import AsyncClient, ASGITransport
 from app.main import app
 
+
+MOCK_USER = {"id": "user-123", "email": "test@example.com", "access_token": "valid_token"}
+
+
+def override_get_user():
+	return MOCK_USER
+
+
+# --- Existing tests (no dependency override needed) ---
+
+
 @pytest.mark.asyncio
 async def test_health_endpoint():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/health")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["status"] == "ok"
-    assert "supabase" in data
-    assert "reachable" in data["supabase"]
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api/health")
+	assert response.status_code == 200
+	data = response.json()
+	assert data["status"] == "ok"
+	assert "supabase" in data
+	assert "reachable" in data["supabase"]
+
 
 @pytest.mark.asyncio
 async def test_root_endpoint():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["message"] == "Fintech FIAP 2026 Core API"
-    assert "version" in data
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api")
+	assert response.status_code == 200
+	data = response.json()
+	assert data["message"] == "Fintech FIAP 2026 Core API"
+	assert "version" in data
+
 
 @pytest.mark.asyncio
 async def test_me_endpoint_no_auth():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/me")
-    assert response.status_code == 401
-    assert response.json() == {"detail": "Missing Authorization header"}
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api/me")
+	assert response.status_code == 401
+	assert response.json() == {"detail": "Missing Authorization header"}
+
 
 @pytest.mark.asyncio
 async def test_me_endpoint_invalid_token():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/me", headers={"Authorization": "Bearer invalid_token"})
-    assert response.status_code == 401
-    assert "Invalid token" in response.json()["detail"]
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api/me", headers={"Authorization": "Bearer invalid_token"})
+	assert response.status_code == 401
+	assert "Invalid token" in response.json()["detail"]
+
+
+# --- Session 3: Transaction & Balance endpoints ---
+
+MOCK_TRANSACTIONS = [
+	{
+		"id": "tx-1",
+		"amount": 150.00,
+		"currency": "BRL",
+		"description": "Grocery store",
+		"category": "food",
+		"created_at": "2026-05-10T10:00:00Z",
+	},
+	{
+		"id": "tx-2",
+		"amount": -50.00,
+		"currency": "BRL",
+		"description": "Transfer out",
+		"category": "transfer",
+		"created_at": "2026-05-11T14:30:00Z",
+	},
+]
+
+MOCK_WALLET = [{
+	"id": "wallet-user-123",
+	"available": 1250.50,
+	"currency": "BRL",
+}]
+
+
+@pytest.mark.asyncio
+async def test_transactions_no_auth():
+	"""Unauthenticated request to /api/transactions returns 401."""
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api/transactions")
+	assert response.status_code == 401
+	assert response.json() == {"detail": "Missing Authorization header"}
+
+
+@pytest.mark.asyncio
+async def test_balance_no_auth():
+	"""Unauthenticated request to /api/balance returns 401."""
+	async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+		response = await ac.get("/api/balance")
+	assert response.status_code == 401
+	assert response.json() == {"detail": "Missing Authorization header"}
+
+
+@pytest.mark.asyncio
+@patch("app.main.httpx.AsyncClient")
+async def test_transactions_authenticated(mock_client_cls):
+	"""Authenticated GET /api/transactions returns Pydantic-schematized list."""
+	from app.main import get_user
+
+	app.dependency_overrides[get_user] = override_get_user
+
+	mock_resp = AsyncMock()
+	mock_resp.status_code = 200
+	mock_resp.json = Mock(return_value=MOCK_TRANSACTIONS)
+
+	mock_client = AsyncMock()
+	mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+	mock_client.__aexit__ = AsyncMock(return_value=False)
+	mock_client.get.return_value = mock_resp
+	mock_client_cls.return_value = mock_client
+
+	try:
+		async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+			response = await ac.get(
+				"/api/transactions",
+				headers={"Authorization": "Bearer valid_token"},
+			)
+		assert response.status_code == 200
+		data = response.json()
+		assert "transactions" in data
+		assert len(data["transactions"]) == 2
+		assert data["transactions"][0]["id"] == "tx-1"
+		assert data["transactions"][0]["amount"] == 150.0
+		assert data["transactions"][1]["amount"] == -50.0
+	finally:
+		app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+@patch("app.main.httpx.AsyncClient")
+async def test_balance_authenticated(mock_client_cls):
+	"""Authenticated GET /api/balance returns Pydantic-schematized balance."""
+	from app.main import get_user
+
+	app.dependency_overrides[get_user] = override_get_user
+
+	mock_resp = AsyncMock()
+	mock_resp.status_code = 200
+	mock_resp.json = Mock(return_value=MOCK_WALLET)
+
+	mock_client = AsyncMock()
+	mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+	mock_client.__aexit__ = AsyncMock(return_value=False)
+	mock_client.get.return_value = mock_resp
+	mock_client_cls.return_value = mock_client
+
+	try:
+		async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+			response = await ac.get(
+				"/api/balance",
+				headers={"Authorization": "Bearer valid_token"},
+			)
+		assert response.status_code == 200
+		data = response.json()
+		assert "balance" in data
+		assert data["balance"]["wallet_id"] == "wallet-user-123"
+		assert data["balance"]["available"] == 1250.5
+		assert data["balance"]["currency"] == "BRL"
+	finally:
+		app.dependency_overrides.clear()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - core-api/.env
     volumes:
-      - ./core-api/app:/app/app
+      - ./core-api/app:/app
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 
   ui-dashboard:

--- a/ui-dashboard/.env.example
+++ b/ui-dashboard/.env.example
@@ -1,0 +1,6 @@
+# Supabase
+REACT_APP_SUPABASE_URL=https://your-project.supabase.co
+REACT_APP_SUPABASE_ANON_KEY=your-anon-key
+
+# Core API
+REACT_APP_API_URL=http://localhost:8080


### PR DESCRIPTION
## What
Implements Session 3 (Core Transaction API) — real fintech domain endpoints.

## Changes
- **Pydantic models**: Transaction, Balance, TransactionsResponse, BalanceResponse
- **GET /api/transactions** — list user transactions from Supabase REST (protected with Depends(get_user))
- **GET /api/balance** — user wallet balance from Supabase REST (protected with Depends(get_user))
- **8/8 tests passing**: auth failure + authenticated happy path (mocked Supabase)
- **Remove stale test_health_score.py** (referenced nonexistent function)
- **Update README** API endpoints table

## Acceptance Criteria (all met)
- [x] Authenticated user can GET /api/transactions
- [x] Authenticated user can GET /api/balance
- [x] Both endpoints return Pydantic-schematized JSON
- [x] pytest covers happy path and auth failure

## Linear
JGF-20 (Add /api/transactions and /api/balance) → Done
JGF-21 (Protect new endpoints with get_user) → Done